### PR TITLE
[Fix] add missing tdqm to yaml

### DIFF
--- a/reconstruction/env.yaml
+++ b/reconstruction/env.yaml
@@ -137,6 +137,7 @@ dependencies:
   - tk=8.6.12=h1ccaba5_0
   - torchaudio=0.13.1=py310_cu116
   - torchvision=0.14.1=py310_cu116
+  - tqdm=4.66.1=pyhd8ed1ab_0
   - typing_extensions=4.4.0=py310h06a4308_0
   - tzdata=2023c=h04d1e81_0
   - urllib3=1.26.15=py310h06a4308_0


### PR DESCRIPTION
running https://github.com/KamitaniLab/brain-decoding-cookbook-public/tree/main/reconstruction

results in

```    from tqdm import tqdm                                                                                                                                                            
ModuleNotFoundError: No module named 'tqdm'
```

this adds tdqm to the yaml file

